### PR TITLE
Fix incorrect signal ID reference

### DIFF
--- a/py/yasimavr/utils/vcd_recorder.py
+++ b/py/yasimavr/utils/vcd_recorder.py
@@ -94,7 +94,7 @@ class _PinDigitalFormatter(Formatter):
     """Formatter specialised for the digital state of GPIO pins.
     """
 
-    _SIGID = _corelib.Pin.SignalId.DigitalStateChange
+    _SIGID = _corelib.Pin.SignalId.DigitalChange
     _PinState = _corelib.Pin.State
 
     def __init__(self, pin):


### PR DESCRIPTION
I believe this line has a typo.
According to https://github.com/clesav/yasimavr/blob/bf7b38882e4dcfa5f2b53e68ea6642513bd74b1c/lib_core/src/core/sim_pin.h#L77-L96 there is no `DigitalStateChange` but there is a `DigitalChange`.

Right now, `yasimavr` fails to start if installed from either PyPi or source:

```shell
# python3 -m yasimavr
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/local/lib64/python3.12/site-packages/yasimavr/__main__.py", line 35, in <module>
    main()
  File "/usr/local/lib64/python3.12/site-packages/yasimavr/__main__.py", line 27, in main
    from yasimavr.cli import simrun
  File "/usr/local/lib64/python3.12/site-packages/yasimavr/cli/simrun.py", line 25, in <module>
    from ..utils.vcd_recorder import Formatter, VCD_Recorder
  File "/usr/local/lib64/python3.12/site-packages/yasimavr/utils/vcd_recorder.py", line 93, in <module>
    class _PinDigitalFormatter(Formatter):
  File "/usr/local/lib64/python3.12/site-packages/yasimavr/utils/vcd_recorder.py", line 97, in _PinDigitalFormatter
    _SIGID = _corelib.Pin.SignalId.DigitalStateChange
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'SignalId' has no attribute 'DigitalStateChange'. Did you mean: 'DigitalChange'?
```