### PR TITLE
Fix GDB path

### DIFF
--- a/py/yasimavr/cli/simrun.py
+++ b/py/yasimavr/cli/simrun.py
@@ -264,7 +264,7 @@ def _run_syncloop():
 
 
 def _run_asyncloop(args):
-    from .utils.gdb_server import GDB_Stub
+    from ..utils.gdb_server import GDB_Stub
 
     global _simloop
 
@@ -325,7 +325,7 @@ def main(args=None):
         if _run_args.gdb is None:
             _run_syncloop()
         else:
-            _run_asyncloop()
+            _run_asyncloop(_run_args)
     except KeyboardInterrupt:
         print('Simulation interrupted !!')
 


### PR DESCRIPTION
Currently the `-g` option seems to be broken.
Fix the below issues:

```shell
# python3 -m yasimavr -f 160000 -m atmega328 -g 1234 mega328_blink_fw.elf
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/local/lib64/python3.12/site-packages/yasimavr/__main__.py", line 35, in <module>
    main()
  File "/usr/local/lib64/python3.12/site-packages/yasimavr/__main__.py", line 29, in main
    simrun.main()
  File "/usr/local/lib64/python3.12/site-packages/yasimavr/cli/simrun.py", line 328, in main
    _run_asyncloop()
TypeError: _run_asyncloop() missing 1 required positional argument: 'args'
```

```shell
# python3 -m yasimavr -f 160000 -m atmega328 -g 1234 mega328_blink_fw.elf
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/local/lib64/python3.12/site-packages/yasimavr/__main__.py", line 35, in <module>
    main()
  File "/usr/local/lib64/python3.12/site-packages/yasimavr/__main__.py", line 29, in main
    simrun.main()
  File "/usr/local/lib64/python3.12/site-packages/yasimavr/cli/simrun.py", line 328, in main
    _run_asyncloop(_run_args)
  File "/usr/local/lib64/python3.12/site-packages/yasimavr/cli/simrun.py", line 267, in _run_asyncloop
    from .utils.gdb_server import GDB_Stub
ModuleNotFoundError: No module named 'yasimavr.cli.utils'
```