### PR TITLE
Ci action update

### DIFF
--- a/.github/workflows/python_build_wheels.yml
+++ b/.github/workflows/python_build_wheels.yml
@@ -22,10 +22,10 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: "pip"
@@ -49,7 +49,7 @@ jobs:
           python -m delvewheel repair $f.FullName --ignore-in-wheel -w ./wheelhouse
         }
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: dist
         path: |
@@ -60,10 +60,10 @@ jobs:
     name: Source Distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
         cache: "pip"
@@ -74,7 +74,7 @@ jobs:
         python -m pip install --upgrade build
         python -m build -s
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist/*.tar.gz
@@ -86,12 +86,12 @@ jobs:
     needs: sdist
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: actions/download-artifact@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
         cache: "pip"

--- a/.github/workflows/python_build_wheels.yml
+++ b/.github/workflows/python_build_wheels.yml
@@ -116,3 +116,12 @@ jobs:
       run: |
         pip install twine
         twine check sdist/*
+
+  merge_artifacts:
+    runs-on: ubuntu-latest
+    needs: [sdist, build_windows]
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: dist

--- a/.github/workflows/python_build_wheels.yml
+++ b/.github/workflows/python_build_wheels.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Build and install package using the sdist
       run: |
         pip install --upgrade pip
-        find dist -type f -name *.tar.gz -fprint dist_req.txt
+        find sdist -type f -name *.tar.gz -fprint dist_req.txt
         pip install -r dist_req.txt -v
 
     - name: Run pytest
@@ -115,4 +115,4 @@ jobs:
     - name: Run twine check
       run: |
         pip install twine
-        twine check dist/*
+        twine check sdist/*

--- a/.github/workflows/python_build_wheels.yml
+++ b/.github/workflows/python_build_wheels.yml
@@ -51,7 +51,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: dist
+        name: wheel-{{ matrix.python-version }}
         path: |
           wheelhouse/*.whl
 
@@ -76,7 +76,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: dist
+        name: sdist
         path: dist/*.tar.gz
 
 

--- a/.github/workflows/python_build_wheels.yml
+++ b/.github/workflows/python_build_wheels.yml
@@ -51,7 +51,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: wheel-{{ matrix.python-version }}
+        name: wheel-${{ matrix.python-version }}
         path: |
           wheelhouse/*.whl
 
@@ -88,7 +88,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
 
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
Update of version for actions :
 - actions/checkout : v3 -> v4
 - actions/setup-python : v4 -> v5
 - actions/upload-artifact : v3 -> v4
 - actions/download-artifact : v3 -> v4
 