### PR TITLE
Adding eeprom_page_size parameter

### DIFF
--- a/bindings/src/lib_arch_xt/arch_xt_nvm.sip
+++ b/bindings/src/lib_arch_xt/arch_xt_nvm.sip
@@ -1,7 +1,7 @@
 /*
  * arch_xt_nvm.sip
  *
- *  Copyright 2022 Clement Savergne <csavergne@yahoo.com>
+ *  Copyright 2022-2024 Clement Savergne <csavergne@yahoo.com>
 
     This file is part of yasim-avr.
 
@@ -58,6 +58,7 @@ struct ArchXT_NVMConfig {
     reg_addr_t reg_base;
 
     mem_addr_t flash_page_size;
+    mem_addr_t eeprom_page_size;
 
     unsigned int buffer_erase_delay;
 

--- a/lib_arch_xt/src/arch_xt_nvm.h
+++ b/lib_arch_xt/src/arch_xt_nvm.h
@@ -95,8 +95,9 @@ struct ArchXT_NVMConfig {
 
     /// Base address for the peripheral I/O registers
     reg_addr_t reg_base;
-    /// Page size for the flash. The EEPROM page size is assumed to be half of it.
+    /// Page size for the flash
     mem_addr_t flash_page_size;
+    /// Page size for the EEPROM
     mem_addr_t eeprom_page_size;
     /// Page buffer erase delay in cycles
     unsigned int buffer_erase_delay;

--- a/lib_arch_xt/src/arch_xt_nvm.h
+++ b/lib_arch_xt/src/arch_xt_nvm.h
@@ -1,7 +1,7 @@
 /*
  * arch_xt_nvm.h
  *
- *  Copyright 2022 Clement Savergne <csavergne@yahoo.com>
+ *  Copyright 2022-2024 Clement Savergne <csavergne@yahoo.com>
 
     This file is part of yasim-avr.
 
@@ -97,6 +97,7 @@ struct ArchXT_NVMConfig {
     reg_addr_t reg_base;
     /// Page size for the flash. The EEPROM page size is assumed to be half of it.
     mem_addr_t flash_page_size;
+    mem_addr_t eeprom_page_size;
     /// Page buffer erase delay in cycles
     unsigned int buffer_erase_delay;
     /// Flash/EEPROM page write operation delay in usecs

--- a/py/yasimavr/device_library/configs/atmega1608.yml
+++ b/py/yasimavr/device_library/configs/atmega1608.yml
@@ -1,6 +1,6 @@
 # YAML configuration file for atmega1608 variant
 #
-# Copyright 2023 Clement Savergne <csavergne@yahoo.com>
+# Copyright 2023-2024 Clement Savergne <csavergne@yahoo.com>
 #
 # This file is part of yasim-avr.
 #
@@ -131,6 +131,7 @@ peripherals:
         ctl_id: NVM
         config:
            flash_page_size: 64
+           eeprom_page_size: 32
            iv_eeready: NVMCTRL_EE
 
     MISC:

--- a/py/yasimavr/device_library/configs/atmega1609.yml
+++ b/py/yasimavr/device_library/configs/atmega1609.yml
@@ -1,6 +1,6 @@
 # YAML configuration file for atmega1609 variant
 #
-# Copyright 2023 Clement Savergne <csavergne@yahoo.com>
+# Copyright 2023-2024 Clement Savergne <csavergne@yahoo.com>
 #
 # This file is part of yasim-avr.
 #
@@ -139,6 +139,7 @@ peripherals:
         ctl_id: NVM
         config:
            flash_page_size: 64
+           eeprom_page_size: 32
            iv_eeready: NVMCTRL_EE
 
     MISC:

--- a/py/yasimavr/device_library/configs/atmega3208.yml
+++ b/py/yasimavr/device_library/configs/atmega3208.yml
@@ -1,6 +1,6 @@
 # YAML configuration file for atmega3208 variant
 #
-# Copyright 2023 Clement Savergne <csavergne@yahoo.com>
+# Copyright 2023-2024 Clement Savergne <csavergne@yahoo.com>
 #
 # This file is part of yasim-avr.
 #
@@ -131,6 +131,7 @@ peripherals:
         ctl_id: NVM
         config:
            flash_page_size: 128
+           eeprom_page_size: 64
            iv_eeready: NVMCTRL_EE
 
     MISC:

--- a/py/yasimavr/device_library/configs/atmega3209.yml
+++ b/py/yasimavr/device_library/configs/atmega3209.yml
@@ -1,6 +1,6 @@
 # YAML configuration file for atmega3209 variant
 #
-# Copyright 2023 Clement Savergne <csavergne@yahoo.com>
+# Copyright 2023-2024 Clement Savergne <csavergne@yahoo.com>
 #
 # This file is part of yasim-avr.
 #
@@ -139,6 +139,7 @@ peripherals:
         ctl_id: NVM
         config:
            flash_page_size: 128
+           eeprom_page_size: 64
            iv_eeready: NVMCTRL_EE
 
     MISC:

--- a/py/yasimavr/device_library/configs/atmega4808.yml
+++ b/py/yasimavr/device_library/configs/atmega4808.yml
@@ -1,6 +1,6 @@
 # YAML configuration file for atmega4808 variant
 #
-# Copyright 2023 Clement Savergne <csavergne@yahoo.com>
+# Copyright 2023-2024 Clement Savergne <csavergne@yahoo.com>
 #
 # This file is part of yasim-avr.
 #
@@ -131,6 +131,7 @@ peripherals:
         ctl_id: NVM
         config:
            flash_page_size: 128
+           eeprom_page_size: 64
            iv_eeready: NVMCTRL_EE
 
     MISC:

--- a/py/yasimavr/device_library/configs/atmega4809.yml
+++ b/py/yasimavr/device_library/configs/atmega4809.yml
@@ -1,6 +1,6 @@
 # YAML configuration file for atmega4809 variant
 #
-# Copyright 2022 Clement Savergne <csavergne@yahoo.com>
+# Copyright 2022-2024 Clement Savergne <csavergne@yahoo.com>
 #
 # This file is part of yasim-avr.
 #
@@ -140,6 +140,7 @@ peripherals:
         ctl_id: NVM
         config:
            flash_page_size: 128
+           eeprom_page_size: 64
            iv_eeready: NVMCTRL_EE
 
     MISC:

--- a/py/yasimavr/device_library/configs/atmega808.yml
+++ b/py/yasimavr/device_library/configs/atmega808.yml
@@ -1,6 +1,6 @@
 # YAML configuration file for atmega808 variant
 #
-# Copyright 2023 Clement Savergne <csavergne@yahoo.com>
+# Copyright 2023-2024 Clement Savergne <csavergne@yahoo.com>
 #
 # This file is part of yasim-avr.
 #
@@ -131,6 +131,7 @@ peripherals:
         ctl_id: NVM
         config:
            flash_page_size: 64
+           eeprom_page_size: 32
            iv_eeready: NVMCTRL_EE
 
     MISC:

--- a/py/yasimavr/device_library/configs/atmega809.yml
+++ b/py/yasimavr/device_library/configs/atmega809.yml
@@ -1,6 +1,6 @@
 # YAML configuration file for atmega809 variant
 #
-# Copyright 2023 Clement Savergne <csavergne@yahoo.com>
+# Copyright 2023-2024 Clement Savergne <csavergne@yahoo.com>
 #
 # This file is part of yasim-avr.
 #
@@ -139,6 +139,7 @@ peripherals:
         ctl_id: NVM
         config:
            flash_page_size: 64
+           eeprom_page_size: 32
            iv_eeready: NVMCTRL_EE
 
     MISC:


### PR DESCRIPTION
Adding a eeprom page size parameter to the NVM controller model for XT architecture, not assuming any more it's 1/2 of the flash page size.