### PR TITLE
AVR WDT model

### DIFF
--- a/bindings/src/lib_arch_avr/arch_avr_wdt.sip
+++ b/bindings/src/lib_arch_avr/arch_avr_wdt.sip
@@ -1,7 +1,7 @@
 /*
  * arch_avr_wdt.sip
  *
- *  Copyright 2021 Clement Savergne <csavergne@yahoo.com>
+ *  Copyright 2021-2024 Clement Savergne <csavergne@yahoo.com>
 
     This file is part of yasim-avr.
 
@@ -37,7 +37,7 @@ struct ArchAVR_WDTConfig {
     bitmask_t bm_int_flag;
     regbit_t rb_reset_flag;
 
-    int_vect_t vector;
+    int_vect_t iv_wdt;
 
 };
 

--- a/bindings/src/lib_arch_avr/arch_avr_wdt.sip
+++ b/bindings/src/lib_arch_avr/arch_avr_wdt.sip
@@ -30,7 +30,7 @@ struct ArchAVR_WDTConfig {
     UnsignedLongVector delays;
 
     reg_addr_t reg_wdt;
-    bitmask_t bm_delay;
+    regbit_compound_t rbc_delay;
     bitmask_t bm_chg_enable;
     bitmask_t bm_reset_enable;
     bitmask_t bm_int_enable;
@@ -41,7 +41,7 @@ struct ArchAVR_WDTConfig {
 
 };
 
-class ArchAVR_WDT : public WatchdogTimer, public InterruptHandler /NoDefaultCtors/ {
+class ArchAVR_WDT : public Peripheral, public InterruptHandler /NoDefaultCtors/ {
 %TypeHeaderCode
 #include "arch_avr_wdt.h"
 %End
@@ -52,11 +52,9 @@ public:
 
     virtual bool init(Device&);
     virtual void reset();
+    virtual bool ctlreq(ctlreq_id_t, ctlreq_data_t*);
+    virtual uint8_t ioreg_read_handler(reg_addr_t, uint8_t);
     virtual void ioreg_write_handler(reg_addr_t, const ioreg_write_t&);
     virtual void interrupt_ack_handler(int_vect_t);
-
-protected:
-
-    virtual void timeout();
 
 };

--- a/bindings/src/lib_arch_avr/arch_avr_wdt.sip
+++ b/bindings/src/lib_arch_avr/arch_avr_wdt.sip
@@ -53,7 +53,6 @@ public:
     virtual bool init(Device&);
     virtual void reset();
     virtual bool ctlreq(ctlreq_id_t, ctlreq_data_t*);
-    virtual uint8_t ioreg_read_handler(reg_addr_t, uint8_t);
     virtual void ioreg_write_handler(reg_addr_t, const ioreg_write_t&);
     virtual void interrupt_ack_handler(int_vect_t);
 

--- a/bindings/src/lib_core/core/peripheral.sip
+++ b/bindings/src/lib_core/core/peripheral.sip
@@ -26,7 +26,7 @@
 #include "core/sim_peripheral.h"
 
 const ctl_id_t IOCTL_CORE       = AVR_IOCTL_CORE;
-const ctl_id_t IOCTL_WTDG       = AVR_IOCTL_WTDG;
+const ctl_id_t IOCTL_WDT        = AVR_IOCTL_WDT;
 const ctl_id_t IOCTL_INTR       = AVR_IOCTL_INTR;
 const ctl_id_t IOCTL_SLEEP      = AVR_IOCTL_SLEEP;
 const ctl_id_t IOCTL_CLOCK      = AVR_IOCTL_CLOCK;
@@ -97,7 +97,7 @@ const ctlreq_id_t CTLREQ_SLEEP_PSEUDO     = AVR_CTLREQ_SLEEP_PSEUDO;
 //=======================================================================================
 
 const ctl_id_t IOCTL_CORE;
-const ctl_id_t IOCTL_WTDG;
+const ctl_id_t IOCTL_WDT;
 const ctl_id_t IOCTL_INTR;
 const ctl_id_t IOCTL_SLEEP;
 const ctl_id_t IOCTL_CLOCK;

--- a/lib_arch_avr/src/arch_avr_wdt.cpp
+++ b/lib_arch_avr/src/arch_avr_wdt.cpp
@@ -33,8 +33,8 @@ ArchAVR_WDT::ArchAVR_WDT(const ArchAVR_WDTConfig& config)
 :Peripheral(AVR_IOCTL_WDT)
 ,m_config(config)
 ,m_timer_start_cycle(0)
-,m_wdt_timer(*this, wdt_timeout)
-,m_lock_timer(*this, lock_timeout)
+,m_wdt_timer(*this, &ArchAVR_WDT::wdt_timeout)
+,m_lock_timer(*this, &ArchAVR_WDT::lock_timeout)
 {}
 
 

--- a/lib_arch_avr/src/arch_avr_wdt.cpp
+++ b/lib_arch_avr/src/arch_avr_wdt.cpp
@@ -1,7 +1,7 @@
 /*
- * arch_avr_wdp.cpp
+ * arch_avr_wdt.cpp
  *
- *  Copyright 2021 Clement Savergne <csavergne@yahoo.com>
+ *  Copyright 2021-2024 Clement Savergne <csavergne@yahoo.com>
 
     This file is part of yasim-avr.
 
@@ -41,7 +41,7 @@ bool ArchAVR_WDT::init(Device& device)
 
     add_ioreg(m_config.reg_wdt);
 
-    status &= register_interrupt(m_config.vector, *this);
+    status &= register_interrupt(m_config.iv_wdt, *this);
 
     return status;
 }
@@ -118,7 +118,7 @@ void ArchAVR_WDT::timeout()
     //restart the timer
     if (int_enable && !int_flag) {
         set_ioreg(m_config.reg_wdt, m_config.bm_int_flag);
-        raise_interrupt(m_config.vector);
+        raise_interrupt(m_config.iv_wdt);
         if (rst_enable) {
             uint8_t delay_index = m_config.bm_delay.extract(reg_value);
             configure_timer(rst_enable, delay_index);

--- a/lib_arch_avr/src/arch_avr_wdt.h
+++ b/lib_arch_avr/src/arch_avr_wdt.h
@@ -85,10 +85,8 @@ private:
 
     void reschedule_timer();
     cycle_count_t calculate_timeout_delay();
-    void configure_timer(bool enable, uint8_t delay_index);
     cycle_count_t wdt_timeout(cycle_count_t when);
     void lock_timeout();
-    void timeout();
 
 };
 

--- a/lib_arch_avr/src/arch_avr_wdt.h
+++ b/lib_arch_avr/src/arch_avr_wdt.h
@@ -1,7 +1,7 @@
 /*
  * arch_avr_wdt.h
  *
- *  Copyright 2021 Clement Savergne <csavergne@yahoo.com>
+ *  Copyright 2021-2024 Clement Savergne <csavergne@yahoo.com>
 
     This file is part of yasim-avr.
 
@@ -57,7 +57,7 @@ struct ArchAVR_WDTConfig {
 	/// Regbit for the reset flag
     regbit_t rb_reset_flag;
     /// Interrupt vector index
-    int_vect_t vector;
+    int_vect_t iv_wdt;
 
 };
 

--- a/lib_arch_avr/src/arch_avr_wdt.h
+++ b/lib_arch_avr/src/arch_avr_wdt.h
@@ -27,7 +27,6 @@
 #include "arch_avr_globals.h"
 #include "core/sim_cycle_timer.h"
 #include "core/sim_interrupt.h"
-#include "ioctrl_common/sim_wdt.h"
 
 YASIMAVR_BEGIN_NAMESPACE
 
@@ -39,22 +38,22 @@ YASIMAVR_BEGIN_NAMESPACE
 struct ArchAVR_WDTConfig {
 
     /// Clock frequency used by the watchdog timer
-	unsigned long clock_frequency;
-	/// List of selectable delays
+    unsigned long clock_frequency;
+    /// List of selectable delays
     std::vector<unsigned long> delays;
     /// WDT configuration register address
     reg_addr_t reg_wdt;
-	/// Bitmask for the delay select
-    bitmask_t bm_delay;
-	/// Bitmask for the Change Enable bit
+    /// Bitmask for the delay select
+    regbit_compound_t rbc_delay;
+    /// Bitmask for the Change Enable bit
     bitmask_t bm_chg_enable;
-	/// Bitmask for the Reset Enable bit
+    /// Bitmask for the Reset Enable bit
     bitmask_t bm_reset_enable;
-	/// Bitmask for the Interrupt Enable bit
+    /// Bitmask for the Interrupt Enable bit
     bitmask_t bm_int_enable;
-	/// Bitmask for the Interrupt Flag bit
+    /// Bitmask for the Interrupt Flag bit
     bitmask_t bm_int_flag;
-	/// Regbit for the reset flag
+    /// Regbit for the reset flag
     regbit_t rb_reset_flag;
     /// Interrupt vector index
     int_vect_t iv_wdt;
@@ -65,7 +64,7 @@ struct ArchAVR_WDTConfig {
 /**
    \brief Implementation of a Watchdog Timer for AVR series
  */
-class AVR_ARCHAVR_PUBLIC_API ArchAVR_WDT : public WatchdogTimer, public InterruptHandler {
+class AVR_ARCHAVR_PUBLIC_API ArchAVR_WDT : public Peripheral, public InterruptHandler {
 
 public:
 
@@ -73,21 +72,23 @@ public:
 
     virtual bool init(Device& device) override;
     virtual void reset() override;
+    virtual bool ctlreq(ctlreq_id_t req, ctlreq_data_t* data) override;
     virtual void ioreg_write_handler(reg_addr_t addr, const ioreg_write_t& data) override;
     virtual void interrupt_ack_handler(int_vect_t vector) override;
 
-protected:
-
-    virtual void timeout() override;
-
 private:
 
-    //Device variant configuration
     const ArchAVR_WDTConfig& m_config;
-    //cycle number when the register have been unlocked for modification
-    cycle_count_t m_unlock_cycle;
+    cycle_count_t m_timer_start_cycle;
+    BoundFunctionCycleTimer<ArchAVR_WDT> m_wdt_timer;
+    BoundFunctionCycleTimer<ArchAVR_WDT> m_lock_timer;
 
+    void reschedule_timer();
+    cycle_count_t calculate_timeout_delay();
     void configure_timer(bool enable, uint8_t delay_index);
+    cycle_count_t wdt_timeout(cycle_count_t when);
+    void lock_timeout();
+    void timeout();
 
 };
 

--- a/lib_core/src/core/sim_cpu.cpp
+++ b/lib_core/src/core/sim_cpu.cpp
@@ -552,7 +552,7 @@ cycle_count_t Core::run_instruction()
                 }   break;
                 case 0x95a8: { // WDR -- Watchdog Reset -- 1001 0101 1010 1000
                     //STATE("wdr\n");
-                    m_device->ctlreq(AVR_IOCTL_WTDG, AVR_CTLREQ_WATCHDOG_RESET);
+                    m_device->ctlreq(AVR_IOCTL_WDT, AVR_CTLREQ_WATCHDOG_RESET);
                 }   break;
                 case 0x95e8:    // SPM -- Store Program Memory -- 1001 0101 1110 1000
                 case 0x95f8: {  // SPM -- Store Program Memory -- 1001 0101 1111 1000 (Z post-increment)

--- a/lib_core/src/core/sim_device.cpp
+++ b/lib_core/src/core/sim_device.cpp
@@ -275,7 +275,7 @@ cycle_count_t Device::exec_cycle()
         cycle_delta = 1;
 
     if (m_state == State_Reset)
-        reset();
+        reset(m_reset_flags);
 
     return cycle_delta;
 }

--- a/lib_core/src/core/sim_device.h
+++ b/lib_core/src/core/sim_device.h
@@ -1,7 +1,7 @@
 /*
  * sim_device.h
  *
- *  Copyright 2021 Clement Savergne <csavergne@yahoo.com>
+ *  Copyright 2021-2024 Clement Savergne <csavergne@yahoo.com>
 
     This file is part of yasim-avr.
 
@@ -74,7 +74,7 @@ public:
         State_Running       = 0x21, //!< Device executing the firmware
         State_Sleeping      = 0x31, //!< Device in sleep mode
         State_Halted        = 0x41, //!< CPU halted but peripherals are running normally
-        State_Reset         = 0x50, //!< Device being reset (taken into account at the next cycle)
+        State_Reset         = 0x51, //!< Device being reset (taken into account at the next cycle)
         State_Break         = 0x60, //!< Device halted by a BREAK instruction
         State_Done          = 0x70, //!< Final state without any error
         State_Crashed       = 0x80, //!< Final state with error

--- a/lib_core/src/core/sim_peripheral.h
+++ b/lib_core/src/core/sim_peripheral.h
@@ -56,7 +56,7 @@ enum class SleepMode;
 /** CTLID for the core: "CORE" */
 #define AVR_IOCTL_CORE              chr_to_id('C', 'O', 'R', 'E')
 /** CTLID for the watchdog timer: "WTDG" */
-#define AVR_IOCTL_WTDG              chr_to_id('W', 'T', 'D', 'G')
+#define AVR_IOCTL_WDT               chr_to_id('W', 'D', 'T', '\0')
 /** CTLID for the interrupt controller: "INTR" */
 #define AVR_IOCTL_INTR              chr_to_id('I', 'N', 'T', 'R')
 /** CTLID for the sleep controller: "SLP" */

--- a/lib_core/src/ioctrl_common/sim_wdt.cpp
+++ b/lib_core/src/ioctrl_common/sim_wdt.cpp
@@ -1,7 +1,7 @@
 /*
  * sim_wdt.cpp
  *
- *  Copyright 2021 Clement Savergne <csavergne@yahoo.com>
+ *  Copyright 2021-2024 Clement Savergne <csavergne@yahoo.com>
 
     This file is part of yasim-avr.
 
@@ -70,7 +70,7 @@ private:
  * Constructor of a generic watchdog timer
  */
 WatchdogTimer::WatchdogTimer()
-:Peripheral(AVR_IOCTL_WTDG)
+:Peripheral(AVR_IOCTL_WDT)
 ,m_clk_factor(0)
 ,m_win_start(0)
 ,m_win_end(0)

--- a/py/yasimavr/device_library/builders/_builders_arch_avr.py
+++ b/py/yasimavr/device_library/builders/_builders_arch_avr.py
@@ -395,6 +395,21 @@ def _get_twi_builder():
 
 
 #========================================================================================
+#Watchdog timer configuration
+
+def _wdt_convertor(cfg, attr, yml_val, per_desc):
+    if attr == 'delays':
+        cfg.delays = list(yml_val)
+    else:
+        raise Exception('Converter not implemented for ' + attr)
+
+
+def _get_wdt_builder():
+    cfg_builder = PeripheralConfigBuilder(_archlib.ArchAVR_WDTConfig, _wdt_convertor)
+    return PeripheralBuilder(_archlib.ArchAVR_WDT, cfg_builder)
+
+
+#========================================================================================
 
 class AVR_BaseDevice(_archlib.ArchAVR_Device):
     """Specialisation of BaseDevicer for the device models using the AVR architecture.
@@ -438,6 +453,7 @@ class AVR_DeviceBuilder(DeviceBuilder):
         'USART': _get_usart_builder,
         'SPI': _get_spi_builder,
         'TWI': _get_twi_builder,
+        'WDT': _get_wdt_builder,
     }
 
     def _build_core_config(self, dev_desc):

--- a/py/yasimavr/device_library/builders/dev_megaxx8.py
+++ b/py/yasimavr/device_library/builders/dev_megaxx8.py
@@ -52,6 +52,7 @@ class dev_megaxx8(AVR_BaseDevice):
             'USART',
             'SPI',
             'TWI',
+            'WDT',
         ]
 
         builder.build_peripherals(self, peripherals)

--- a/py/yasimavr/device_library/configs/atmega168.yml
+++ b/py/yasimavr/device_library/configs/atmega168.yml
@@ -1,6 +1,6 @@
 # YAML configuration file for atmega168 variant
 #
-# Copyright 2023 Clement Savergne <csavergne@yahoo.com>
+# Copyright 2023-2024 Clement Savergne <csavergne@yahoo.com>
 #
 # This file is part of yasim-avr.
 #
@@ -152,7 +152,6 @@ peripherals:
 
     WDT:
         file: mega48-88-168-328_timers.yml
-        ctl_id: WTDG
 
     ADC:
         file: mega48-88-168-328_analog.yml

--- a/py/yasimavr/device_library/configs/atmega328.yml
+++ b/py/yasimavr/device_library/configs/atmega328.yml
@@ -163,7 +163,6 @@ peripherals:
 
     WDT:
         file: mega48-88-168-328_timers.yml
-        ctl_id: WTDG
 
     ADC:
         file: mega48-88-168-328_analog.yml

--- a/py/yasimavr/device_library/configs/atmega48.yml
+++ b/py/yasimavr/device_library/configs/atmega48.yml
@@ -1,6 +1,6 @@
 # YAML configuration file for atmega48 variant
 #
-# Copyright 2023 Clement Savergne <csavergne@yahoo.com>
+# Copyright 2023-2024 Clement Savergne <csavergne@yahoo.com>
 #
 # This file is part of yasim-avr.
 #
@@ -149,7 +149,6 @@ peripherals:
 
     WDT:
         file: mega48-88-168-328_timers.yml
-        ctl_id: WTDG
 
     ADC:
         file: mega48-88-168-328_analog.yml

--- a/py/yasimavr/device_library/configs/atmega88.yml
+++ b/py/yasimavr/device_library/configs/atmega88.yml
@@ -1,6 +1,6 @@
 # YAML configuration file for atmega88 variant
 #
-# Copyright 2023 Clement Savergne <csavergne@yahoo.com>
+# Copyright 2023-2024 Clement Savergne <csavergne@yahoo.com>
 #
 # This file is part of yasim-avr.
 #
@@ -152,7 +152,6 @@ peripherals:
 
     WDT:
         file: mega48-88-168-328_timers.yml
-        ctl_id: WTDG
 
     ADC:
         file: mega48-88-168-328_analog.yml

--- a/py/yasimavr/device_library/configs/mega48-88-168-328_timers.yml
+++ b/py/yasimavr/device_library/configs/mega48-88-168-328_timers.yml
@@ -1,6 +1,6 @@
 # YAML configuration file for atmega48-88-168-328 variants
 #
-# Copyright 2021 Clement Savergne <csavergne@yahoo.com>
+# Copyright 2021-2024 Clement Savergne <csavergne@yahoo.com>
 #
 # This file is part of yasim-avr.
 #
@@ -595,5 +595,17 @@ WDT:
             WDP3: { kind: BIT, pos: 5 }
             WDIE: { kind: BIT, pos: 6 }
             WDIF: { kind: BIT, pos: 7 }
+
+    config:
+        clock_frequency: 128000
+        delays: [ 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576 ]
+        reg_wdt: WDT/WDTCSR
+        bm_delay: WDTCSR/WDP|WDP3
+        bm_chg_enable: WDTCSR/WDCE
+        bm_reset_enable: WDTCSR/WDE
+        bm_int_enable: WDTCSR/WDIE
+        bm_int_flag: WDTCSR/WDIF
+        rb_reset_flag: RSTCTRL/MCUSR/WDRF
+        iv_wdt: WDT
 
 #========================================================================================

--- a/py/yasimavr/device_library/configs/mega48-88-168-328_timers.yml
+++ b/py/yasimavr/device_library/configs/mega48-88-168-328_timers.yml
@@ -600,7 +600,7 @@ WDT:
         clock_frequency: 128000
         delays: [ 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576 ]
         reg_wdt: WDT/WDTCSR
-        bm_delay: WDTCSR/WDP|WDP3
+        rbc_delay: [ WDTCSR/WDP, WDTCSR/WDP3 ]
         bm_chg_enable: WDTCSR/WDCE
         bm_reset_enable: WDTCSR/WDE
         bm_int_enable: WDTCSR/WDIE

--- a/py/yasimavr/device_library/descriptors.py
+++ b/py/yasimavr/device_library/descriptors.py
@@ -796,12 +796,7 @@ def convert_to_regbit_compound(arg, per=None, dev=None):
         l = _parse_regpath(_split_reg_path(regpath), per, dev)
         regbit_list.extend(l)
 
-        return _corelib.regbit_compound_t(regbit_list)
-
-    else:
-        elements = _split_reg_path(arg)
-        regbit_list = _parse_regpath(elements, per, dev)
-        return _corelib.regbit_compound_t(regbit_list)
+    return _corelib.regbit_compound_t(regbit_list)
 
 
 def convert_to_bitmask(arg, per=None, dev=None):

--- a/tests/test_avr_wdt.py
+++ b/tests/test_avr_wdt.py
@@ -1,0 +1,113 @@
+# test_avr_wdt.py
+#
+# Copyright 2024 Clement Savergne <csavergne@yahoo.com>
+#
+# This file is part of yasim-avr.
+#
+# yasim-avr is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# yasim-avr is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with yasim-avr.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+from _test_bench_avr import bench_m328
+from _test_utils import PinState, DictSignalHook
+from yasimavr.lib.core import Logger, Device
+
+
+'''
+Test of the watchdog timer on ATMega328
+'''
+
+
+@pytest.fixture
+def bench():
+    return bench_m328()
+
+
+def test_avr_watchdog_interrupt(bench):
+    WDTCSR = bench.dev.WDT.WDTCSR
+    MCUCSR = bench.dev.RSTCTRL.MCUSR
+    CPU = bench.dev.CPU
+
+    per_wdt = bench.dev_model.find_peripheral('WDT')
+    per_wdt.logger().set_level(Logger.Level.Debug)
+
+    WDTCSR.WDIE = 1
+    CPU.SREG.I = 0
+    assert not WDTCSR.WDIF
+    bench.sim_advance(16000) #16ms
+    assert WDTCSR.WDIF
+    assert WDTCSR.WDIE
+    assert not MCUCSR.WDRF
+
+    CPU.SREG.I = 1
+    bench.sim_advance(100)
+    assert not WDTCSR.WDIF
+    assert not WDTCSR.WDIE
+    assert CPU.GPIOR0 == 6
+
+
+def test_avr_watchdog_change_protection(bench):
+    WDTCSR = bench.dev.WDT.WDTCSR
+
+    WDTCSR.WDP = '4K'
+    assert WDTCSR.WDP == '2K'
+
+    with WDTCSR:
+        WDTCSR.WDCE = 1
+        WDTCSR.WDP = '4K'
+    assert WDTCSR.WDP == '2K'
+
+    with WDTCSR:
+        WDTCSR.WDCE = 1
+        WDTCSR.WDE = 1
+    WDTCSR.WDP = '4K'
+    assert WDTCSR.WDP == '4K'
+
+    bench.sim_advance(2)
+    with WDTCSR:
+        WDTCSR.WDCE = 0
+        WDTCSR.WDP = '8K'
+    assert WDTCSR.WDCE
+    assert WDTCSR.WDP == '8K'
+
+    bench.sim_advance(3)
+    with WDTCSR:
+        WDTCSR.WDCE = 0
+        WDTCSR.WDP = '2K'
+    assert not WDTCSR.WDCE
+    assert WDTCSR.WDP == '8K'
+
+
+def test_avr_watchdog_timeout(bench):
+    WDTCSR = bench.dev.WDT.WDTCSR
+    MCUSR = bench.dev.RSTCTRL.MCUSR
+
+    with WDTCSR:
+        WDTCSR.WDCE = 1
+        WDTCSR.WDE = 1
+
+    with WDTCSR:
+        WDTCSR.WDE = 1
+        WDTCSR.WDP = '2K'
+        WDTCSR.WDIE = 1
+
+    bench.sim_advance(15001)
+    assert WDTCSR.WDIF
+
+    bench.sim_advance(1)
+    assert not WDTCSR.WDIF
+    assert not WDTCSR.WDIE
+    assert WDTCSR.WDE
+
+    bench.sim_advance(16000)
+    assert MCUSR.WDRF


### PR DESCRIPTION
Rewrite of the watchdog timer model for AVR series, to correctly simulate all the bits the WDTCSR register.