### PR TITLE
BoundFunction template

### DIFF
--- a/bindings/src/lib_arch_avr/arch_avr_acp.sip
+++ b/bindings/src/lib_arch_avr/arch_avr_acp.sip
@@ -50,7 +50,7 @@ struct ArchAVR_ACPConfig {
 };
 
 
-class ArchAVR_ACP : public Peripheral, public SignalHook /NoDefaultCtors/ {
+class ArchAVR_ACP : public Peripheral /NoDefaultCtors/ {
 %TypeHeaderCode
 #include "arch_avr_acp.h"
 %End
@@ -58,7 +58,5 @@ class ArchAVR_ACP : public Peripheral, public SignalHook /NoDefaultCtors/ {
 public:
 
     ArchAVR_ACP(int, const ArchAVR_ACPConfig& /KeepReference/);
-
-    virtual void raised(const signal_data_t&, int);
 
 };

--- a/bindings/src/lib_arch_avr/arch_avr_adc.sip
+++ b/bindings/src/lib_arch_avr/arch_avr_adc.sip
@@ -69,7 +69,7 @@ struct ArchAVR_ADCConfig {
 };
 
 
-class ArchAVR_ADC : public Peripheral, public SignalHook /NoDefaultCtors/ {
+class ArchAVR_ADC : public Peripheral /NoDefaultCtors/ {
 %TypeHeaderCode
 #include "arch_avr_adc.h"
 %End
@@ -77,7 +77,5 @@ class ArchAVR_ADC : public Peripheral, public SignalHook /NoDefaultCtors/ {
 public:
 
     ArchAVR_ADC(int, const ArchAVR_ADCConfig& /KeepReference/);
-
-    virtual void raised(const signal_data_t&, int);
 
 };

--- a/bindings/src/lib_arch_avr/arch_avr_timer.sip
+++ b/bindings/src/lib_arch_avr/arch_avr_timer.sip
@@ -174,7 +174,7 @@ struct ArchAVR_TimerConfig {
 };
 
 
-class ArchAVR_Timer : public Peripheral, public SignalHook /NoDefaultCtors/ {
+class ArchAVR_Timer : public Peripheral /NoDefaultCtors/ {
 %TypeHeaderCode
 #include "arch_avr_timer.h"
 %End
@@ -189,7 +189,5 @@ public:
     };
 
     ArchAVR_Timer(int, const ArchAVR_TimerConfig& /KeepReference/);
-
-    virtual void raised(const signal_data_t&, int);
 
 };

--- a/bindings/src/lib_arch_xt/arch_xt_acp.sip
+++ b/bindings/src/lib_arch_xt/arch_xt_acp.sip
@@ -48,7 +48,7 @@ struct ArchXT_ACPConfig {
 };
 
 
-class ArchXT_ACP : public Peripheral, public SignalHook /NoDefaultCtors/ {
+class ArchXT_ACP : public Peripheral /NoDefaultCtors/ {
 %TypeHeaderCode
 #include "arch_xt_acp.h"
 %End
@@ -56,7 +56,5 @@ class ArchXT_ACP : public Peripheral, public SignalHook /NoDefaultCtors/ {
 public:
 
     ArchXT_ACP(int, const ArchXT_ACPConfig& /KeepReference/);
-
-    virtual void raised(const signal_data_t&, int);
 
 };

--- a/bindings/src/lib_arch_xt/arch_xt_adc.sip
+++ b/bindings/src/lib_arch_xt/arch_xt_adc.sip
@@ -48,7 +48,7 @@ struct ArchXT_ADCConfig {
 };
 
 
-class ArchXT_ADC : public Peripheral, public SignalHook /NoDefaultCtors/ {
+class ArchXT_ADC : public Peripheral /NoDefaultCtors/ {
 %TypeHeaderCode
 #include "arch_xt_adc.h"
 %End
@@ -56,7 +56,5 @@ class ArchXT_ADC : public Peripheral, public SignalHook /NoDefaultCtors/ {
 public:
 
     ArchXT_ADC(int, const ArchXT_ADCConfig& /KeepReference/);
-
-    virtual void raised(const signal_data_t&, int);
 
 };

--- a/bindings/src/lib_arch_xt/arch_xt_nvm.sip
+++ b/bindings/src/lib_arch_xt/arch_xt_nvm.sip
@@ -68,7 +68,7 @@ struct ArchXT_NVMConfig {
 };
 
 
-class ArchXT_NVM : public Peripheral, public SignalHook /NoDefaultCtors/ {
+class ArchXT_NVM : public Peripheral /NoDefaultCtors/ {
 %TypeHeaderCode
 #include "arch_xt_nvm.h"
 %End
@@ -76,7 +76,5 @@ class ArchXT_NVM : public Peripheral, public SignalHook /NoDefaultCtors/ {
 public:
 
     ArchXT_NVM(const ArchXT_NVMConfig& /KeepReference/);
-
-    virtual void raised(const signal_data_t&, int);
 
 };

--- a/bindings/src/lib_arch_xt/arch_xt_timer_a.sip
+++ b/bindings/src/lib_arch_xt/arch_xt_timer_a.sip
@@ -71,7 +71,7 @@ struct ArchXT_TimerAConfig {
 };
 
 
-class ArchXT_TimerA : public Peripheral, public SignalHook /NoDefaultCtors/ {
+class ArchXT_TimerA : public Peripheral /NoDefaultCtors/ {
 %TypeHeaderCode
 #include "arch_xt_timer_a.h"
 %End
@@ -88,7 +88,5 @@ public:
     };
 
     ArchXT_TimerA(const ArchXT_TimerAConfig& /KeepReference/);
-
-    virtual void raised(const signal_data_t&, int);
 
 };

--- a/bindings/src/lib_arch_xt/arch_xt_timer_b.sip
+++ b/bindings/src/lib_arch_xt/arch_xt_timer_b.sip
@@ -50,7 +50,7 @@ struct ArchXT_TimerBConfig {
 };
 
 
-class ArchXT_TimerB : public Peripheral, public SignalHook /NoDefaultCtors/ {
+class ArchXT_TimerB : public Peripheral /NoDefaultCtors/ {
 %TypeHeaderCode
 #include "arch_xt_timer_b.h"
 %End
@@ -68,7 +68,5 @@ public:
     };
 
     ArchXT_TimerB(int, const ArchXT_TimerBConfig& /KeepReference/);
-
-    virtual void raised(const signal_data_t&, int);
 
 };

--- a/lib_arch_avr/src/arch_avr_acp.cpp
+++ b/lib_arch_avr/src/arch_avr_acp.cpp
@@ -49,6 +49,7 @@ ArchAVR_ACP::ArchAVR_ACP(int num, const ArchAVR_ACPConfig& config)
 :Peripheral(AVR_IOCTL_ACP(0x30 + num))
 ,m_config(config)
 ,m_intflag(true)
+,m_input_hook(*this, &ArchAVR_ACP::input_raised)
 ,m_pos_value(0.0)
 ,m_neg_value(0.0)
 {}
@@ -107,8 +108,8 @@ bool ArchAVR_ACP::init(Device& device)
         m_neg_mux.add_mux(pin->signal(), Pin::Signal_VoltageChange);
     }
 
-    m_pos_mux.signal().connect(*this, HookTag_Pos);
-    m_neg_mux.signal().connect(*this, HookTag_Neg);
+    m_pos_mux.signal().connect(m_input_hook, HookTag_Pos);
+    m_neg_mux.signal().connect(m_input_hook, HookTag_Neg);
 
     return status;
 }
@@ -202,7 +203,7 @@ void ArchAVR_ACP::update_state()
 /*
  * Hook callback, the hooktag determines if it's for the positive or the negative side
  */
-void ArchAVR_ACP::raised(const signal_data_t& sigdata, int hooktag)
+void ArchAVR_ACP::input_raised(const signal_data_t& sigdata, int hooktag)
 {
     if (hooktag == HookTag_Pos)
         m_pos_value = sigdata.data.as_double();

--- a/lib_arch_avr/src/arch_avr_acp.h
+++ b/lib_arch_avr/src/arch_avr_acp.h
@@ -82,8 +82,7 @@ struct ArchAVR_ACPConfig {
    CTLREQs supported:
     - AVR_CTLREQ_GET_SIGNAL : returns a pointer to the instance signal
  */
-class AVR_ARCHAVR_PUBLIC_API ArchAVR_ACP : public Peripheral,
-                                           public SignalHook {
+class AVR_ARCHAVR_PUBLIC_API ArchAVR_ACP : public Peripheral {
 
 public:
 
@@ -93,7 +92,6 @@ public:
     virtual void reset(int flags) override;
     virtual bool ctlreq(ctlreq_id_t req, ctlreq_data_t* data) override;
     virtual void ioreg_write_handler(reg_addr_t addr, const ioreg_write_t& data) override;
-    virtual void raised(const signal_data_t& sigdata, int hooktag) override;
 
 private:
 
@@ -101,12 +99,14 @@ private:
     InterruptFlag m_intflag;
     DataSignalMux m_pos_mux;
     DataSignalMux m_neg_mux;
+    BoundFunctionSignalHook<ArchAVR_ACP> m_input_hook;
     Signal m_out_signal;
     double m_pos_value;
     double m_neg_value;
 
     void change_pos_channel();
     void change_neg_channel();
+    void input_raised(const signal_data_t& sigdata, int hooktag);
     void update_state();
 
 };

--- a/lib_arch_avr/src/arch_avr_adc.cpp
+++ b/lib_arch_avr/src/arch_avr_adc.cpp
@@ -41,6 +41,7 @@ ArchAVR_ADC::ArchAVR_ADC(int num, const CFG& config)
 ,m_config(config)
 ,m_state(ADC_Disabled)
 ,m_first(true)
+,m_timer_hook(*this, &ArchAVR_ADC::timer_raised)
 ,m_trigger(CFG::Trig_Manual)
 ,m_temperature(25.0)
 ,m_latched_ch_mux(0)
@@ -74,7 +75,7 @@ bool ArchAVR_ADC::init(Device& device)
                              m_config.int_vector);
 
     m_timer.init(*device.cycle_manager(), logger());
-    m_timer.signal().connect(*this);
+    m_timer.signal().connect(m_timer_hook);
 
     return status;
 }
@@ -288,7 +289,7 @@ void ArchAVR_ADC::read_analog_value()
 }
 
 
-void ArchAVR_ADC::raised(const signal_data_t& sigdata, int)
+void ArchAVR_ADC::timer_raised(const signal_data_t& sigdata, int)
 {
     if (sigdata.index != 1) return;
 

--- a/lib_arch_avr/src/arch_avr_adc.h
+++ b/lib_arch_avr/src/arch_avr_adc.h
@@ -117,8 +117,7 @@ struct ArchAVR_ADCConfig {
     The trigger only works when the ADC is enabled and idle, auto-trigger is enabled and
     an external trigger source is selected.
  */
-class AVR_ARCHAVR_PUBLIC_API ArchAVR_ADC : public Peripheral,
-                                           public SignalHook {
+class AVR_ARCHAVR_PUBLIC_API ArchAVR_ADC : public Peripheral {
 
 public:
 
@@ -130,7 +129,6 @@ public:
     virtual uint8_t ioreg_read_handler(reg_addr_t addr, uint8_t value) override;
     virtual void ioreg_write_handler(reg_addr_t addr, const ioreg_write_t& data) override;
     virtual void sleep(bool on, SleepMode mode) override;
-    virtual void raised(const signal_data_t& sigdata, int hooktag) override;
 
 private:
 
@@ -154,6 +152,7 @@ private:
 
     //Timer to simulate the conversion cycle duration
     PrescaledTimer m_timer;
+    BoundFunctionSignalHook<ArchAVR_ADC> m_timer_hook;
 
     //Simulated device temperature value in deg Celsius
     double m_temperature;
@@ -173,7 +172,7 @@ private:
 
     void start_conversion_cycle();
     void reset_prescaler();
-    void timer_raised();
+    void timer_raised(const signal_data_t& sigdata, int hooktag);
 
     void read_analog_value();
     void write_digital_value();

--- a/lib_arch_avr/src/arch_avr_timer.cpp
+++ b/lib_arch_avr/src/arch_avr_timer.cpp
@@ -32,28 +32,6 @@ typedef ArchAVR_TimerConfig CFG;
 
 
 /*
- * Implementation of a SignalHook for event capture. It just forwards to the main class.
- */
-class ArchAVR_Timer::CaptureHook : public SignalHook {
-
-public:
-
-    CaptureHook(ArchAVR_Timer& timer) : m_timer(timer) {}
-    virtual ~CaptureHook() {}
-
-    virtual void raised(const signal_data_t&, int) override
-    {
-        m_timer.capt_raised();
-    }
-
-private:
-
-    ArchAVR_Timer& m_timer;
-
-};
-
-
-/*
  * Implementation of the structure that hold configuration and data for each
  * OutputCompare module
  */
@@ -91,8 +69,10 @@ ArchAVR_Timer::ArchAVR_Timer(int num, const CFG& config)
 ,m_icr(0)
 ,m_temp(0)
 ,m_counter((m_config.is_16bits ? 0x10000 : 0x100), m_config.oc_channels.size())
+,m_cnt_hook(*this, &ArchAVR_Timer::cnt_raised)
 ,m_intflag_ovf(true)
 ,m_intflag_icr(true)
+,m_capt_hook(*this, &ArchAVR_Timer::capt_raised)
 {
     //Calculate the prescaler max value by looking for the highest division factor
     m_clk_ps_max = 0;
@@ -100,8 +80,6 @@ ArchAVR_Timer::ArchAVR_Timer(int num, const CFG& config)
         if (clkcfg.div > m_clk_ps_max)
             m_clk_ps_max = clkcfg.div;
     }
-
-    m_capt_hook = new CaptureHook(*this);
 
     for (auto& oc_cfg : m_config.oc_channels) {
         OutputCompareChannel* oc = new OutputCompareChannel(oc_cfg);
@@ -112,8 +90,6 @@ ArchAVR_Timer::ArchAVR_Timer(int num, const CFG& config)
 
 ArchAVR_Timer::~ArchAVR_Timer()
 {
-    delete m_capt_hook;
-
     for (auto oc : m_oc_channels)
         delete oc;
 }
@@ -166,7 +142,7 @@ bool ArchAVR_Timer::init(Device& device)
     add_ioreg(m_config.reg_int_flag, bitmask_t(int_bitmask), IORegister::Strobe);
 
     m_counter.init(*device.cycle_manager(), logger());
-    m_counter.signal().connect(*this);
+    m_counter.signal().connect(m_cnt_hook);
 
     return status;
 }
@@ -435,7 +411,7 @@ bool ArchAVR_Timer::output_active(CFG::COM_config_t& mode, size_t output_index)
 }
 
 
-void ArchAVR_Timer::raised(const signal_data_t& sigdata, int)
+void ArchAVR_Timer::cnt_raised(const signal_data_t& sigdata, int)
 {
     if (sigdata.sigid == TimerCounter::Signal_Event) {
         int event_flags = sigdata.data.as_int();
@@ -557,7 +533,7 @@ void ArchAVR_Timer::change_OC_state(size_t index, int event_flags)
 }
 
 
-void ArchAVR_Timer::capt_raised()
+void ArchAVR_Timer::capt_raised(const signal_data_t&, int)
 {
     //If no ICR is registered, the Input Capture function is unavailable
     if (!m_config.reg_icr.valid()) return;

--- a/lib_arch_avr/src/arch_avr_timer.h
+++ b/lib_arch_avr/src/arch_avr_timer.h
@@ -228,7 +228,7 @@ struct ArchAVR_TimerConfig {
    Unsupported features:
         - Asynchronous operations
  */
-class AVR_ARCHAVR_PUBLIC_API ArchAVR_Timer : public Peripheral, public SignalHook {
+class AVR_ARCHAVR_PUBLIC_API ArchAVR_Timer : public Peripheral {
 
 public:
 
@@ -260,12 +260,7 @@ public:
     virtual uint8_t ioreg_peek_handler(reg_addr_t addr, uint8_t value) override;
     virtual void ioreg_write_handler(reg_addr_t addr, const ioreg_write_t& data) override;
 
-    virtual void raised(const signal_data_t& sigdata, int hooktag) override;
-
 private:
-
-    class CaptureHook;
-    friend class CaptureHook;
 
     struct OutputCompareChannel;
     friend struct OutputCompareChannel;
@@ -284,14 +279,16 @@ private:
     std::vector<OutputCompareChannel*> m_oc_channels;
     //Timer counter engine
     TimerCounter m_counter;
+    BoundFunctionSignalHook<ArchAVR_Timer> m_cnt_hook;
     //Interrupt and signal management
     InterruptFlag m_intflag_ovf;
     InterruptFlag m_intflag_icr;
     DataSignal m_signal;
-    CaptureHook* m_capt_hook;
+    BoundFunctionSignalHook<ArchAVR_Timer> m_capt_hook;
 
+    void cnt_raised(const signal_data_t& sigdata, int hooktag);
     void update_top();
-    void capt_raised();
+    void capt_raised(const signal_data_t& sigdata, int hooktag);
     ArchAVR_TimerConfig::COM_config_t get_COM_config(uint8_t regval);
     void change_OC_state(size_t index, int event_flags);
     bool output_active(ArchAVR_TimerConfig::COM_config_t& mode, size_t output_index);

--- a/lib_arch_xt/src/arch_xt_acp.cpp
+++ b/lib_arch_xt/src/arch_xt_acp.cpp
@@ -63,6 +63,7 @@ ArchXT_ACP::ArchXT_ACP(int num, const cfg_t& config)
 ,m_config(config)
 ,m_intflag(false)
 ,m_vref_signal(nullptr)
+,m_hook(*this, &ArchXT_ACP::input_raised)
 ,m_sleeping(false)
 ,m_hysteresis(0.0)
 {
@@ -88,7 +89,7 @@ bool ArchXT_ACP::init(Device& device)
 
     m_vref_signal = dynamic_cast<DataSignal*>(get_signal(AVR_IOCTL_VREF));
     if (m_vref_signal) {
-        m_vref_signal->connect(*this, HookTag_VREF);
+        m_vref_signal->connect(m_hook, HookTag_VREF);
     } else {
         logger().err("No VREF peripheral found.");
         status = false;
@@ -97,8 +98,8 @@ bool ArchXT_ACP::init(Device& device)
     status &= register_channels(m_pos_mux, m_config.pos_channels);
     status &= register_channels(m_neg_mux, m_config.neg_channels);
 
-    m_pos_mux.signal().connect(*this, HookTag_PosMux);
-    m_neg_mux.signal().connect(*this, HookTag_NegMux);
+    m_pos_mux.signal().connect(m_hook, HookTag_PosMux);
+    m_neg_mux.signal().connect(m_hook, HookTag_NegMux);
 
     return status;
 }
@@ -289,7 +290,7 @@ void ArchXT_ACP::update_output()
 /*
 * Callback from the pin signal hook.
 */
-void ArchXT_ACP::raised(const signal_data_t& sigdata, int hooktag)
+void ArchXT_ACP::input_raised(const signal_data_t& sigdata, int hooktag)
 {
     if (hooktag == HookTag_VREF) {
         if (sigdata.sigid == VREF::Signal_IntRefChange && sigdata.index == m_config.vref_channel) {

--- a/lib_arch_xt/src/arch_xt_acp.h
+++ b/lib_arch_xt/src/arch_xt_acp.h
@@ -76,8 +76,7 @@ struct ArchXT_ACPConfig {
     - AVR_CTLREQ_GET_SIGNAL : returns a pointer to the instance signal
     - AVR_CTLREQ_ACP_GET_DAC : returns the output value of the internal DAC.
  */
-class AVR_ARCHXT_PUBLIC_API ArchXT_ACP : public Peripheral,
-                                         public SignalHook {
+class AVR_ARCHXT_PUBLIC_API ArchXT_ACP : public Peripheral {
 
 public:
 
@@ -88,7 +87,6 @@ public:
     virtual bool ctlreq(ctlreq_id_t req, ctlreq_data_t* data) override;
     virtual void ioreg_write_handler(reg_addr_t addr, const ioreg_write_t& data) override;
     virtual void sleep(bool on, SleepMode mode) override;
-    virtual void raised(const signal_data_t& sigdata, int hooktag) override;
 
 private:
 
@@ -99,12 +97,14 @@ private:
     DataSignal* m_vref_signal;
     DataSignalMux m_pos_mux;
     DataSignalMux m_neg_mux;
+    BoundFunctionSignalHook<ArchXT_ACP> m_hook;
     //Boolean indicating if the peripheral is disabled by the current sleep mode
     bool m_sleeping;
     //Hysteresis value
     double m_hysteresis;
 
     bool register_channels(DataSignalMux& mux, const std::vector<ACP::channel_config_t>& channels);
+    void input_raised(const signal_data_t& sigdata, int hooktag);
     void update_DAC();
     void update_hysteresis();
     void update_output();

--- a/lib_arch_xt/src/arch_xt_adc.cpp
+++ b/lib_arch_xt/src/arch_xt_adc.cpp
@@ -51,6 +51,7 @@ ArchXT_ADC::ArchXT_ADC(int num, const CFG& config)
 ,m_config(config)
 ,m_state(ADC_Disabled)
 ,m_first(false)
+,m_timer_hook(*this, &ArchXT_ADC::timer_raised)
 ,m_temperature(25.0)
 ,m_latched_ch_mux(0)
 ,m_latched_ref_mux(0)
@@ -97,7 +98,7 @@ bool ArchXT_ADC::init(Device& device)
                                  m_config.iv_wincmp);
 
     m_timer.init(*device.cycle_manager(), logger());
-    m_timer.signal().connect(*this);
+    m_timer.signal().connect(m_timer_hook);
 
     return status;
 }
@@ -305,7 +306,7 @@ void ArchXT_ADC::read_analog_value()
  * First, we perform the actual analog read.
  * Second, we store it in the data register and raise the interrupt flag
  */
-void ArchXT_ADC::raised(const signal_data_t& sigdata, int)
+void ArchXT_ADC::timer_raised(const signal_data_t& sigdata, int)
 {
     if (sigdata.index != 1) return;
 

--- a/lib_arch_xt/src/arch_xt_adc.h
+++ b/lib_arch_xt/src/arch_xt_adc.h
@@ -86,8 +86,7 @@ struct ArchXT_ADCConfig {
     - AVR_CTLREQ_ADC_TRIGGER : Allows other peripherals to trigger a conversion.
     The trigger only works when the ADC is enabled and idle, and the bit STARTEI is set.
  */
-class AVR_ARCHXT_PUBLIC_API ArchXT_ADC : public Peripheral,
-                                         public SignalHook {
+class AVR_ARCHXT_PUBLIC_API ArchXT_ADC : public Peripheral {
 
 public:
 
@@ -99,7 +98,6 @@ public:
     virtual uint8_t ioreg_read_handler(reg_addr_t addr, uint8_t value) override;
     virtual void ioreg_write_handler(reg_addr_t addr, const ioreg_write_t& data) override;
     virtual void sleep(bool on, SleepMode mode) override;
-    virtual void raised(const signal_data_t& sigdata, int hooktag) override;
 
 private:
 
@@ -115,6 +113,7 @@ private:
     State m_state;
     bool m_first;
     PrescaledTimer m_timer;
+    BoundFunctionSignalHook<ArchXT_ADC> m_timer_hook;
     double m_temperature;
     uint8_t m_latched_ch_mux;
     uint8_t m_latched_ref_mux;
@@ -128,6 +127,7 @@ private:
 
     void start_conversion_cycle();
     void read_analog_value();
+    void timer_raised(const signal_data_t& sigdata, int hooktag);
 
 };
 

--- a/lib_arch_xt/src/arch_xt_nvm.cpp
+++ b/lib_arch_xt/src/arch_xt_nvm.cpp
@@ -202,24 +202,6 @@ void ArchXT_Fuses::configure_flash_sections()
 #define NVM_INDEX_INVALID   -2
 
 
-class ArchXT_NVM::Timer : public CycleTimer {
-
-public:
-
-    Timer(ArchXT_NVM& ctl) : m_ctl(ctl) {}
-
-    virtual cycle_count_t next(cycle_count_t when) override {
-        m_ctl.timer_next();
-        return 0;
-    }
-
-private:
-
-    ArchXT_NVM& m_ctl;
-
-};
-
-
 ArchXT_NVM::ArchXT_NVM(const ArchXT_NVMConfig& config)
 :Peripheral(AVR_IOCTL_NVM)
 ,m_config(config)
@@ -228,18 +210,16 @@ ArchXT_NVM::ArchXT_NVM(const ArchXT_NVMConfig& config)
 ,m_bufset(nullptr)
 ,m_mem_index(NVM_INDEX_NONE)
 ,m_page(0)
+,m_timer(*this, &ArchXT_NVM::timer_next)
 ,m_ee_intflag(false)
 ,m_section_manager(nullptr)
+,m_section_hook(*this, &ArchXT_NVM::section_raised)
 ,m_pending_bootlock(false)
-{
-    m_timer = new Timer(*this);
-}
+{}
 
 
 ArchXT_NVM::~ArchXT_NVM()
 {
-    delete m_timer;
-
     if (m_buffer)
         free(m_buffer);
     if (m_bufset)
@@ -273,6 +253,7 @@ bool ArchXT_NVM::init(Device& device)
     if (!device.ctlreq(AVR_IOCTL_CORE, AVR_CTLREQ_CORE_SECTIONS, &req))
         return false;
     m_section_manager = req.data.as_ptr<MemorySectionManager>();
+    m_section_manager->signal().connect(m_section_hook);
 
     return status;
 }
@@ -490,7 +471,7 @@ void ArchXT_NVM::execute_command(Command cmd)
             device()->ctlreq(AVR_IOCTL_CORE, AVR_CTLREQ_CORE_HALT, &d);
         }
 
-        device()->cycle_manager()->delay(*m_timer, delay);
+        device()->cycle_manager()->delay(m_timer, delay);
     }
 }
 
@@ -578,7 +559,7 @@ void ArchXT_NVM::timer_next()
 }
 
 
-void ArchXT_NVM::raised(const signal_data_t& sigdata, int)
+void ArchXT_NVM::section_raised(const signal_data_t& sigdata, int)
 {
     //If there is a pending bootlock and the CPU is leaving the boot section
     if (m_pending_bootlock &&

--- a/lib_arch_xt/src/arch_xt_nvm.h
+++ b/lib_arch_xt/src/arch_xt_nvm.h
@@ -124,7 +124,7 @@ struct ArchXT_NVMConfig {
     - AVR_CTLREQ_NVM_REQUEST : Used internally when the CPU writes to a data space address
     mapped to a NVM block. Used to redirect the write to the page buffer.
  */
-class AVR_ARCHXT_PUBLIC_API ArchXT_NVM : public Peripheral, public SignalHook {
+class AVR_ARCHXT_PUBLIC_API ArchXT_NVM : public Peripheral {
 
 public:
 
@@ -135,12 +135,8 @@ public:
     virtual void reset(int flags) override;
     virtual bool ctlreq(ctlreq_id_t req, ctlreq_data_t* data) override;
     virtual void ioreg_write_handler(reg_addr_t addr, const ioreg_write_t& data) override;
-    virtual void raised(const signal_data_t& sigdata, int hooktag) override;
 
 private:
-
-    class Timer;
-    friend class Timer;
 
     enum Command {
         Cmd_Idle,
@@ -164,11 +160,12 @@ private:
     uint8_t* m_bufset;
     int m_mem_index;
     mem_addr_t m_page;
-    Timer* m_timer;
+    BoundFunctionCycleTimer<ArchXT_NVM> m_timer;
 
     InterruptFlag m_ee_intflag;
 
     MemorySectionManager* m_section_manager;
+    BoundFunctionSignalHook<ArchXT_NVM> m_section_hook;
     bool m_pending_bootlock;
 
     NonVolatileMemory* get_memory(int nvm_index);
@@ -177,6 +174,7 @@ private:
     void execute_command(Command cmd);
     unsigned int execute_page_command(Command cmd);
     void timer_next();
+    void section_raised(const signal_data_t& sigdata, int hooktag);
 
 };
 

--- a/lib_arch_xt/src/arch_xt_timer_a.cpp
+++ b/lib_arch_xt/src/arch_xt_timer_a.cpp
@@ -128,6 +128,7 @@ ArchXT_TimerA::ArchXT_TimerA(const ArchXT_TimerAConfig& config)
 ,m_sgl_counter(0x10000, 3)
 ,m_lo_counter(0x100, 3)
 ,m_hi_counter(0x100, 3)
+,m_counter_hook(*this, &ArchXT_TimerA::counter_raised)
 ,m_wgmode(TCA_SINGLE_WGMODE_NORMAL_gc)
 ,m_EIA_state(false)
 ,m_EIB_state(false)
@@ -224,15 +225,15 @@ bool ArchXT_TimerA::init(Device& device)
 
     m_sgl_counter.init(*device.cycle_manager(), logger());
     m_timer.register_chained_timer(m_sgl_counter.prescaler());
-    m_sgl_counter.signal().connect(*this, Tag_Single);
+    m_sgl_counter.signal().connect(m_counter_hook, Tag_Single);
 
     m_lo_counter.init(*device.cycle_manager(), logger());
     m_timer.register_chained_timer(m_lo_counter.prescaler());
-    m_lo_counter.signal().connect(*this, Tag_SplitLow);
+    m_lo_counter.signal().connect(m_counter_hook, Tag_SplitLow);
 
     m_hi_counter.init(*device.cycle_manager(), logger());
     m_timer.register_chained_timer(m_hi_counter.prescaler());
-    m_hi_counter.signal().connect(*this, Tag_SplitHigh);
+    m_hi_counter.signal().connect(m_counter_hook, Tag_SplitHigh);
 
     device.pin_manager().register_driver(*m_pin_driver);
 
@@ -929,7 +930,7 @@ void ArchXT_TimerA::update_compare_outputs(int change)
 }
 
 
-void ArchXT_TimerA::raised(const signal_data_t& sigdata, int hooktag)
+void ArchXT_TimerA::counter_raised(const signal_data_t& sigdata, int hooktag)
 {
     if (hooktag == Tag_Single)
         process_counter_single(sigdata);

--- a/lib_arch_xt/src/arch_xt_timer_a.h
+++ b/lib_arch_xt/src/arch_xt_timer_a.h
@@ -103,7 +103,7 @@ struct ArchXT_TimerAConfig {
 
   The model supports two versions, defined by the `version`attribute of ArchXT_TimerAConfig
  */
-class AVR_ARCHXT_PUBLIC_API ArchXT_TimerA : public Peripheral, public SignalHook {
+class AVR_ARCHXT_PUBLIC_API ArchXT_TimerA : public Peripheral {
 
 public:
 
@@ -127,8 +127,6 @@ public:
     virtual uint8_t ioreg_peek_handler(reg_addr_t addr, uint8_t value) override;
     virtual void ioreg_write_handler(reg_addr_t addr, const ioreg_write_t& data) override;
     virtual void sleep(bool on, SleepMode mode) override;
-    //Override of Hook callback
-    virtual void raised(const signal_data_t& sigdata, int hooktag) override;
 
 private:
 
@@ -165,6 +163,7 @@ private:
     TimerCounter m_sgl_counter; //Main counter in Single mode
     TimerCounter m_lo_counter; //Low-byte counter in Split mode
     TimerCounter m_hi_counter; //High-byte counter in Split mode
+    BoundFunctionSignalHook<ArchXT_TimerA> m_counter_hook;
 
     uint8_t m_wgmode;
 
@@ -190,6 +189,7 @@ private:
     void set_compare_output(unsigned int index, int change);
     void update_compare_outputs(int change = 0);
 
+    void counter_raised(const signal_data_t& sigdata, int hooktag);
     void process_counter_single(const signal_data_t& sigdata);
     void process_counter_split(const signal_data_t& sigdata, bool low_cnt);
 

--- a/lib_arch_xt/src/arch_xt_timer_b.cpp
+++ b/lib_arch_xt/src/arch_xt_timer_b.cpp
@@ -97,6 +97,7 @@ ArchXT_TimerB::ArchXT_TimerB(int num, const CFG& config)
 ,m_output(0)
 ,m_intflag(false)
 ,m_counter(0x10000, 1)
+,m_counter_hook(*this, &ArchXT_TimerB::counter_raised)
 ,m_event_hook(*this, &ArchXT_TimerB::event_hook_raised)
 {
     m_pin_driver = new _PinDriver(id());
@@ -137,7 +138,7 @@ bool ArchXT_TimerB::init(Device& device)
                              m_config.iv_capt);
 
     m_counter.init(*device.cycle_manager(), logger());
-    m_counter.signal().connect(*this);
+    m_counter.signal().connect(m_counter_hook);
 
     status &= device.pin_manager().register_driver(*m_pin_driver);
 
@@ -340,7 +341,7 @@ void ArchXT_TimerB::update_on_CCMP_read()
 }
 
 
-void ArchXT_TimerB::raised(const signal_data_t& data, int hooktag)
+void ArchXT_TimerB::counter_raised(const signal_data_t& data, int)
 {
     if (data.sigid != TimerCounter::Signal_Event) return;
 

--- a/lib_arch_xt/src/arch_xt_timer_b.h
+++ b/lib_arch_xt/src/arch_xt_timer_b.h
@@ -63,7 +63,7 @@ struct ArchXT_TimerBConfig {
    - Debug run override
    - Synchronize Update (SYNCUPD)
  */
-class AVR_ARCHXT_PUBLIC_API ArchXT_TimerB : public Peripheral, public SignalHook {
+class AVR_ARCHXT_PUBLIC_API ArchXT_TimerB : public Peripheral {
 
 public:
 
@@ -88,8 +88,6 @@ public:
     virtual uint8_t ioreg_peek_handler(reg_addr_t addr, uint8_t value) override;
     virtual void ioreg_write_handler(reg_addr_t addr, const ioreg_write_t& data) override;
     virtual void sleep(bool on, SleepMode mode) override;
-    //Override of Hook callback
-    virtual void raised(const signal_data_t& sigdata, int hooktag) override;
 
 private:
 
@@ -116,6 +114,7 @@ private:
 
     //***** Timer management *****
     TimerCounter m_counter;
+    BoundFunctionSignalHook<ArchXT_TimerB> m_counter_hook;
 
     BoundFunctionSignalHook<ArchXT_TimerB> m_event_hook;
 
@@ -124,6 +123,7 @@ private:
     _PinDriver* m_pin_driver;
 
     void set_counter_state(State state);
+    void counter_raised(const signal_data_t& sigdata, int hooktag);
     void update_counter_top();
     void update_on_CCMP_read();
     void process_capture_event(unsigned char event_state);

--- a/lib_core/src/ioctrl_common/sim_timer.cpp
+++ b/lib_core/src/ioctrl_common/sim_timer.cpp
@@ -1,7 +1,7 @@
 /*
  * sim_timer.cpp
  *
- *  Copyright 2021-2024 Clement Savergne <csavergne@yahoo.com>
+ *  Copyright 2021-2026 Clement Savergne <csavergne@yahoo.com>
 
     This file is part of yasim-avr.
 
@@ -343,49 +343,6 @@ cycle_count_t PrescaledTimer::ticks_to_event(cycle_count_t counter, cycle_count_
 
 //=======================================================================================
 
-/*
- * Implementation of a SignalHook for external clocking. It just forwards to the main class.
- */
-class TimerCounter::TimerHook : public SignalHook {
-
-public:
-
-    TimerHook(TimerCounter& timer) : m_timer(timer) {}
-
-    virtual void raised(const signal_data_t& sigdata, int) override
-    {
-        m_timer.timer_raised(sigdata);
-    }
-
-private:
-
-    TimerCounter& m_timer;
-
-};
-
-
-/*
- * Implementation of a SignalHook for external clocking. It just forwards to the main class.
- */
-class TimerCounter::ExtTickHook : public SignalHook {
-
-public:
-
-    ExtTickHook(TimerCounter& timer) : m_timer(timer) {}
-
-    virtual void raised(const signal_data_t&, int) override
-    {
-        if (m_timer.m_source == Tick_External)
-            m_timer.add_tick();
-    }
-
-private:
-
-    TimerCounter& m_timer;
-
-};
-
-
 /**
    Constructor
    \param wrap Wrapping value for the counter. For example, a 16-bits counter wrap is 0x10000.
@@ -400,19 +357,11 @@ TimerCounter::TimerCounter(long wrap, size_t comp_count)
 ,m_countdown(false)
 ,m_cmp(comp_count)
 ,m_next_event_type(0)
+,m_timer_hook(*this, &TimerCounter::timer_raised)
+,m_ext_hook(*this, &TimerCounter::extclock_raised)
 ,m_logger(nullptr)
 {
-    m_timer_hook = new TimerHook(*this);
-    m_ext_hook = new ExtTickHook(*this);
-
-    m_timer.signal().connect(*m_timer_hook);
-}
-
-
-TimerCounter::~TimerCounter()
-{
-    delete m_timer_hook;
-    delete m_ext_hook;
+    m_timer.signal().connect(m_timer_hook);
 }
 
 
@@ -612,7 +561,7 @@ long TimerCounter::delay_to_event()
    Callback from the internal prescaled timer
    Process the timer ticks, by updating the counter
  */
-void TimerCounter::timer_raised(const signal_data_t& sigdata)
+void TimerCounter::timer_raised(const signal_data_t& sigdata, int)
 {
     if (m_logger)
         m_logger->dbg("Updating counters");
@@ -624,7 +573,7 @@ void TimerCounter::timer_raised(const signal_data_t& sigdata)
 /*
  * Callback for a single external clock tick.
  */
-void TimerCounter::extclock_raised()
+void TimerCounter::extclock_raised(const signal_data_t&, int)
 {
     if (m_source == Tick_External)
         tick();

--- a/lib_core/src/ioctrl_common/sim_timer.h
+++ b/lib_core/src/ioctrl_common/sim_timer.h
@@ -1,7 +1,7 @@
 /*
  * sim_timer.h
  *
- *  Copyright 2021 Clement Savergne <csavergne@yahoo.com>
+ *  Copyright 2021-2026 Clement Savergne <csavergne@yahoo.com>
 
     This file is part of yasim-avr.
 
@@ -212,7 +212,6 @@ public:
     };
 
     TimerCounter(long wrap, size_t comp_count);
-    ~TimerCounter();
 
     void init(CycleManager& cycle_manager, Logger& logger);
 
@@ -256,12 +255,6 @@ public:
 
 private:
 
-    class TimerHook;
-    friend class TimerHook;
-
-    class ExtTickHook;
-    friend class ExtTickHook;
-
     struct CompareUnit {
         long value = 0;
         bool enabled = false;
@@ -288,14 +281,14 @@ private:
     uint8_t m_next_event_type;
     //Signal management
     DataSignal m_signal;
-    TimerHook* m_timer_hook;
-    ExtTickHook* m_ext_hook;
+    BoundFunctionSignalHook<TimerCounter> m_timer_hook;
+    BoundFunctionSignalHook<TimerCounter> m_ext_hook;
     //Logging
     Logger* m_logger;
 
     long delay_to_event();
-    void timer_raised(const signal_data_t& sigdata);
-    void extclock_raised();
+    void timer_raised(const signal_data_t& sigdata, int);
+    void extclock_raised(const signal_data_t&, int);
     void add_tick();
     long ticks_to_event(long event);
     void process_ticks(long ticks, bool event_reached);
@@ -367,7 +360,7 @@ inline Signal& TimerCounter::signal()
 /// Getter for the external signal hook used for tick source
 inline SignalHook& TimerCounter::ext_tick_hook()
 {
-    return *reinterpret_cast<SignalHook*>(m_ext_hook);
+    return m_ext_hook;
 }
 
 /// Getter for the internal prescaler


### PR DESCRIPTION
Spreading use of BoundFunctionSignalHook and BoundFunctionCycleTimer templates to remove more boilerplate code in peripheral models.